### PR TITLE
Correct problems of selection - mainly visible with thumbnails view

### DIFF
--- a/src/main/webapp/css/esup-stock.css
+++ b/src/main/webapp/css/esup-stock.css
@@ -387,7 +387,7 @@ background-color: #f8f8f8 !important;
 }
 
 .esupstock .disabled_upload input {
-cursor: auto !important;                                 
+cursor: auto !important;
 }
 
 /* Common */
@@ -552,6 +552,9 @@ margin-left: 5px;
 	width: 100%;
 	height: 100%;
 	overflow: hidden;
+}
+.esupstock .thumbnail .inner_thumbnail > input {
+    position: absolute;
 }
 
 .esupstock .thumbnail a img {

--- a/src/main/webapp/js/esup-stock.js
+++ b/src/main/webapp/js/esup-stock.js
@@ -972,7 +972,7 @@ function handleLeftTreeSelection(treeNode) {
         type: 'POST',
         url: htmlFileTreeURL,
         data: {
-            "dir": path        
+            "dir": path
         },
         success: function (r) {
             console.log("handleLeftTreeSelection: htmlFileTree ajax call succeeded");
@@ -1398,8 +1398,8 @@ function downloadFile(fileName) {
 
     console.log("downloadFile. Path: " + fileName);
 
-    var url = /\?/.test(downloadFileURL) ? downloadFileURL + '&' : downloadFileURL + '?'; 
-    url = url + 'dir=' + encodeURIComponent(fileName); 
+    var url = /\?/.test(downloadFileURL) ? downloadFileURL + '&' : downloadFileURL + '?';
+    url = url + 'dir=' + encodeURIComponent(fileName);
 
     console.log(url);
     //window.open(url);
@@ -1689,7 +1689,7 @@ function deleteFiles(dirsDataStruct) {
 	      action on both the click and double click events*/
 
 	    var jqElem = $(this);
-		  
+
 	    //Retrieve how many times this element has been clicked
 	    var clicks = 1 + (jqElem.data("clicks") ? jqElem.data("clicks") : 0);
 
@@ -1711,7 +1711,7 @@ function deleteFiles(dirsDataStruct) {
 
 	      //Store timeout function id in case we need to cancel it
 	      jqElem.data("singleClickFuncId", singleClickFuncId);
-	    } 
+	    }
 
 	    return false;
 	  }
@@ -1788,6 +1788,7 @@ function deleteFiles(dirsDataStruct) {
     function handleItemSelection(elemClicked, event) {
         console.log("handleItemSelection " + elemClicked);
 
+        var isElemChecked = isChecked(elemClicked);
 
         if (event.ctrlKey) {
             console.log("Ctrl key pressed");
@@ -1801,8 +1802,10 @@ function deleteFiles(dirsDataStruct) {
             clearSelections();
         }
 
-        if (isChecked(elemClicked)) {
+        if (isElemChecked) {
             console.log("Current row selected");
+            // to resolve the bug of selection after the clearSelection we reselect the element to refresh the page with a deselectObject
+            selectObject(elemClicked, false);
             deselectObject(elemClicked, true);
         } else {
             console.log("Current row not selected");
@@ -1851,10 +1854,10 @@ function deleteFiles(dirsDataStruct) {
       var elems = $(selector);
 
 
-	    
+
 	  if(useDoubleClick == "false") {
 		  console.log("Binding single click like dbleClick");
-		  elems.bind('click', handleItemDblClick);	  
+		  elems.bind('click', handleItemDblClick);
 	  } else {
 		  console.log("Binding single click");
 		  elems.bind('click', handleItemDblOrOneClick);
@@ -2121,25 +2124,25 @@ $.authenticate = function(dir, username, password) { authenticate(dir, username,
 
 // keyboard events
 
-  var isCtrl = false; 
-  var isShift = false; 
+  var isCtrl = false;
+  var isShift = false;
 
-  $(document).keyup(function(e) { 
-    if(e.which == 17) isCtrl=false; 
-    if(e.which == 16) isShift=false;   
+  $(document).keyup(function(e) {
+    if(e.which == 17) isCtrl=false;
+    if(e.which == 16) isShift=false;
   });
-  
+
   $(document).keydown(function(e) {
-    
+
     if(e.which == 17) { isCtrl=true; return; }
     if(e.which == 16) { isShift=true; return; }
-   
+
     if(e.which == 86 && isCtrl) {
       console.log("Ctrl-v key pressed");
       pasteFiles();
       return;
     }
-    
+
 
     if (e.which == 9) {
 		console.log("Tab key pressed");
@@ -2150,12 +2153,12 @@ $.authenticate = function(dir, username, password) { authenticate(dir, username,
 		selectObject(getJqueryObj(selectableItems[0]), true);
 		return;
 	}
-    
+
     var dirs = getCheckedDirs();
     if (dirs == null || dirs.length == 0) {
       return;
     }
-    
+
     switch (e.which) {
     case 67:
       if(isCtrl) {
@@ -2172,11 +2175,11 @@ $.authenticate = function(dir, username, password) { authenticate(dir, username,
     case 46:
       console.log("Suppr key pressed");
       deleteFiles();
-      break;    
+      break;
     case 113:
       console.log("F2 key pressed");
       handleRename();
-      break; 
+      break;
     case 13:
       // if e.target.nodeName  != BODY maybe we're on dialog / form, etc ...
       if(e.target.nodeName == 'BODY') {
@@ -2188,7 +2191,7 @@ $.authenticate = function(dir, username, password) { authenticate(dir, username,
           openAndSelectLiNode(baSelData.path);
 	}
       }
-      break;  
+      break;
     case 38:
         console.log("Up key pressed");
         e.preventDefault();
@@ -2226,9 +2229,9 @@ $.authenticate = function(dir, username, password) { authenticate(dir, username,
         handleBrowserAreaSelection();
     	break;
     }
-    
+
     return;
-    
+
   });
 
 


### PR DESCRIPTION
When we select an item in thumbnail view the unselect doesn't work, and the buton to download files isn't desactivated which when we click on show an error page of emtpy item list to download. Also this patch correct when we want to unselect with a second click an item wasn't unselected this is working now.

Warning this patch wasn't tested with current version (current bug version 2.1.0), but the code of the method didn't change since this version.
