### PR TITLE
Adding Drive Access checking feature with evaluators 

### DIFF
--- a/src/main/java/org/esupportail/portlet/filemanager/portlet/PortletController.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/portlet/PortletController.java
@@ -47,50 +47,47 @@ import org.springframework.web.portlet.ModelAndView;
 public class PortletController {
 
 	protected Logger log = Logger.getLogger(PortletController.class);
-	
+
 	public static final String PREF_ESUPSTOCK_CONTEXTTOKEN = "contextToken";
 	public static final String PREF_PORTLET_VIEW = "defaultPortletView";
 	public static final String PREF_DEFAULT_PATH = "defaultPath";
 	public static final String PREF_SHOW_HIDDEN_FILES = "showHiddenFiles";
 	public static final String PREF_USE_DOUBLE_CLICK = "useDoubleClick";
 	public static final String PREF_USE_CURSOR_WAIT_DIALOG = "useCursorWaitDialog";
-	
+
 	public static final String STANDARD_VIEW = "standard";
 	public static final String MOBILE_VIEW = "mobile";
 	public static final String WAI_VIEW = "wai";
-	
+
 	@Autowired
 	protected IServersAccessService serverAccess;
-	
+
 	@Autowired
 	protected UserAgentInspector userAgentInspector;
-	
+
 	@Autowired
 	protected SharedUserPortletParameters userParameters;
 
 	@Autowired
 	protected PathEncodingUtils pathEncodingUtils;
-	
-	protected void init(PortletRequest request) {		
-			
+
+	protected void init(PortletRequest request) {
+
 		if(!userParameters.isInitialized()) {
 			String clientIpAdress = request.getProperty("REMOTE_ADDR");
-	    	userParameters.init(clientIpAdress);			
-	        
-	    	final PortletPreferences prefs = request.getPreferences();
-	    	String contextToken = prefs.getValue(PREF_ESUPSTOCK_CONTEXTTOKEN, null);
-	    	
-			Map userInfos = (Map) request.getAttribute(PortletRequest.USER_INFO);	
+	    	userParameters.init(clientIpAdress);
+
+			Map userInfos = (Map) request.getAttribute(PortletRequest.USER_INFO);
 			userParameters.setUserInfos(userInfos);
-			
-			List<String> driveNames = serverAccess.getRestrictedDrivesGroupsContext(request, contextToken, userInfos);
+
+			List<String> driveNames = serverAccess.getRestrictedDrivesGroupsContext(request);
 			userParameters.setDriveNames(driveNames);
-						
-	   		log.info("set SharedUserPortletParameters in application session");   		
+
+	   		log.info("set SharedUserPortletParameters in application session");
 		}
 
 	}
-		
+
     @RequestMapping("VIEW")
     protected ModelAndView renderView(RenderRequest request, RenderResponse response) throws Exception {
     	this.init(request);
@@ -102,16 +99,16 @@ public class PortletController {
     		for(String prefDefaultPath: prefsDefaultPathes)
     			log.debug("- " + prefDefaultPath);
     	}
-    	
-    	boolean showHiddenFiles = "true".equals(prefs.getValue(PREF_SHOW_HIDDEN_FILES, "false")); 	
+
+    	boolean showHiddenFiles = "true".equals(prefs.getValue(PREF_SHOW_HIDDEN_FILES, "false"));
     	userParameters.setShowHiddenFiles(showHiddenFiles);
-    	
+
     	serverAccess.initializeServices(userParameters);
-    	
+
     	String defaultPath = serverAccess.getFirstAvailablePath(userParameters, prefsDefaultPathes);
     	log.info("defaultPath will be : " + defaultPath);
     	defaultPath = pathEncodingUtils.encodeDir(defaultPath);
-    	
+
 	    if(userAgentInspector.isMobile(request)) {
 			return this.browseMobile(request, response, defaultPath);
 	    } else {
@@ -123,15 +120,15 @@ public class PortletController {
 	    		return this.browseStandard(request, response, defaultPath);
 	    }
     }
-    
+
 	@RequestMapping(value = {"VIEW"}, params = {"action=browseStandard"})
-    public ModelAndView browseStandard(RenderRequest request, RenderResponse response, String dir) {	
+    public ModelAndView browseStandard(RenderRequest request, RenderResponse response, String dir) {
     	this.init(request);
         final PortletPreferences prefs = request.getPreferences();
-		boolean useDoubleClick = "true".equals(prefs.getValue(PREF_USE_DOUBLE_CLICK, "true")); 
+		boolean useDoubleClick = "true".equals(prefs.getValue(PREF_USE_DOUBLE_CLICK, "true"));
     	boolean useCursorWaitDialog = "true".equals(prefs.getValue(PREF_USE_CURSOR_WAIT_DIALOG, "false"));
-    	
-		ModelMap model = new ModelMap();     
+
+		ModelMap model = new ModelMap();
 		model.put("useDoubleClick", useDoubleClick);
 		model.put("useCursorWaitDialog", useCursorWaitDialog);
 		if(dir == null)
@@ -139,14 +136,14 @@ public class PortletController {
 		model.put("defaultPath", dir);
     	return new ModelAndView("view-portlet", model);
     }
-    
+
 	@RequestMapping(value = {"VIEW"}, params = {"action=browseMobile"})
     public ModelAndView browseMobile(RenderRequest request, RenderResponse response,
     								@RequestParam String dir) {
     	this.init(request);
-    	
+
 		String decodedDir = pathEncodingUtils.decodeDir(dir);
-		
+
 		ModelMap model;
 		if( !(dir == null || dir.length() == 0 || decodedDir.equals(JsTreeFile.ROOT_DRIVE)) ) {
 			if(this.serverAccess.formAuthenticationRequired(decodedDir, userParameters)) {
@@ -163,19 +160,19 @@ public class PortletController {
 		model = browse(dir);
         return new ModelAndView("view-portlet-mobile", model);
     }
-	
+
 	@RequestMapping(value = {"VIEW"}, params = {"action=browseWai"})
     public ModelAndView browseWai(RenderRequest request, RenderResponse response,
     								@RequestParam(required=false) String dir,
     								@RequestParam(required=false) String msg) {
 		this.init(request);
-		
+
 		String decodedDir = pathEncodingUtils.decodeDir(dir);
-		
+
 		if(!serverAccess.isInitialized(userParameters)) {
 			serverAccess.initializeServices(userParameters);
 		}
-		
+
 		ModelMap model;
 		if( !(dir == null || dir.length() == 0 || decodedDir.equals(JsTreeFile.ROOT_DRIVE)) ) {
 			if(this.serverAccess.formAuthenticationRequired(decodedDir, userParameters)) {
@@ -185,12 +182,12 @@ public class PortletController {
 				model.put("parentDir", parentDir);
 				model.put("username", this.serverAccess.getUserPassword(decodedDir, userParameters).getUsername());
 				model.put("password", this.serverAccess.getUserPassword(decodedDir, userParameters).getPassword());
-				if(msg != null) 
+				if(msg != null)
 					model.put("msg",msg);
 				return new ModelAndView("authenticationForm-portlet-wai", model);
 			}
 		}
-		
+
 		model = browse(dir);
 		FormCommand command = new FormCommand();
 	    model.put("command", command);
@@ -211,17 +208,17 @@ public class PortletController {
 		model.put("files", files);
 		model.put("currentDir", dir);
 		ListOrderedMap parentsEncPathes = pathEncodingUtils.getParentsEncPathes(resource);
-		model.put("parentsEncPathes", parentsEncPathes); 
+		model.put("parentsEncPathes", parentsEncPathes);
 		return model;
 	}
-	
+
     @RequestMapping("ABOUT")
 	public ModelAndView renderAboutView(RenderRequest request, RenderResponse response) throws Exception {
 		this.init(request);
 		ModelMap model = new ModelMap();
 		return new ModelAndView("about-portlet", model);
 	}
-    
+
     @RequestMapping("HELP")
 	public ModelAndView renderHelpView(RenderRequest request, RenderResponse response) throws Exception {
 		this.init(request);

--- a/src/main/java/org/esupportail/portlet/filemanager/services/FsAccess.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/FsAccess.java
@@ -30,6 +30,7 @@ import org.esupportail.portlet.filemanager.beans.SharedUserPortletParameters;
 import org.esupportail.portlet.filemanager.beans.UserPassword;
 import org.esupportail.portlet.filemanager.services.auth.FormUserPasswordAuthenticatorService;
 import org.esupportail.portlet.filemanager.services.auth.UserAuthenticatorService;
+import org.esupportail.portlet.filemanager.services.evaluators.IDriveAccessEvaluator;
 import org.esupportail.portlet.filemanager.services.uri.UriManipulateService;
 
 public abstract class FsAccess {
@@ -42,11 +43,7 @@ public abstract class FsAccess {
 
     protected String datePattern = "dd/MM/yyyy HH:mm";
 
-	private List<String> memberOfAny;
-
-	private Map<String, String> hasAttributs;
-
-	private String contextToken;
+	private IDriveAccessEvaluator evaluator;
 
 	protected String driveName;
 
@@ -64,28 +61,12 @@ public abstract class FsAccess {
 		this.datePattern = datePattern;
 	}
 
-	public List<String> getMemberOfAny() {
-		return memberOfAny;
+	public IDriveAccessEvaluator getEvaluator() {
+		return evaluator;
 	}
 
-	public void setMemberOfAny(List<String> memberOfAny) {
-		this.memberOfAny = memberOfAny;
-	}
-
-	public Map<String, String> getHasAttributs() {
-		return hasAttributs;
-	}
-
-	public void setHasAttributs(Map<String, String> hasAttributs) {
-		this.hasAttributs = hasAttributs;
-	}
-
-	public String getContextToken() {
-		return contextToken;
-	}
-
-	public void setContextToken(String contextToken) {
-		this.contextToken = contextToken;
+	public void setEvaluator(final IDriveAccessEvaluator evaluator) {
+		this.evaluator = evaluator;
 	}
 
 	public String getDriveName() {
@@ -192,7 +173,7 @@ public abstract class FsAccess {
 	public UserPassword getUserPassword(SharedUserPortletParameters userParameters) {
 		if(this.userAuthenticatorService != null)
 			return this.userAuthenticatorService.getUserPassword(userParameters);
-		else 
+		else
 			return null;
 	}
 

--- a/src/main/java/org/esupportail/portlet/filemanager/services/IServersAccessService.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/IServersAccessService.java
@@ -37,7 +37,7 @@ public interface IServersAccessService {
 	public abstract void setServers(List<FsAccess> servers);
 
 	public abstract List<String> getRestrictedDrivesGroupsContext(
-			PortletRequest request, String contextToken, Map userInfos);
+			PortletRequest request);
 
 	public abstract void initializeServices(
 			SharedUserPortletParameters userParameters);

--- a/src/main/java/org/esupportail/portlet/filemanager/services/ServersAccessService.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/ServersAccessService.java
@@ -80,57 +80,15 @@ public class ServersAccessService implements DisposableBean, IServersAccessServi
 	@Autowired
 	protected PathEncodingUtils pathEncodingUtils;
 
-	public List<String> getRestrictedDrivesGroupsContext(PortletRequest request,
-			String contextToken, Map userInfos) {
+	public List<String> getRestrictedDrivesGroupsContext(PortletRequest request) {
 
 		List<String> driveNames = new ArrayList<String>(this.servers.keySet());
 
-		// contextToken restriction
-		if(contextToken != null) {
-			for(FsAccess server: this.servers.values()) {
-				if(server.getContextToken() == null || !contextToken.equals(server.getContextToken())) {
-					driveNames.remove(server.getDriveName());
-				}
+		for(FsAccess server: this.servers.values()) {
+			if(server.getEvaluator() != null && !server.getEvaluator().isApplicable(request) ) {
+				driveNames.remove(server.getDriveName());
 			}
 		}
-
-		// groups restriction
-		if(request != null)
-			for(FsAccess server: this.servers.values()) {
-				boolean isUserInAnyRole = false;
-				if(server.getMemberOfAny() != null) {
-					for(String group: server.getMemberOfAny()) {
-						if(request.isUserInRole(group)) {
-							isUserInAnyRole = true;
-							break;
-						}
-					}
-				} else {
-					// if null -> no restriction
-					isUserInAnyRole = true;
-				}
-				if(!isUserInAnyRole)
-					driveNames.remove(server.getDriveName());
-		}
-
-		// HasAttribut restriction
-		if(userInfos != null)
-			for(FsAccess server: this.servers.values()) {
-				boolean userHasAttributs = true;
-				if(server.getHasAttributs() != null) {
-					for(String attr: server.getHasAttributs().keySet()) {
-						String attrValue = (String)userInfos.get(attr);
-						String regex = server.getHasAttributs().get(attr);
-						if(attrValue == null || !attrValue.matches(regex)) {
-							userHasAttributs = false;
-							break;
-						}
-					}
-				}
-
-				if(!userHasAttributs)
-					driveNames.remove(server.getDriveName());
-			}
 
 		return driveNames;
 	}
@@ -451,12 +409,12 @@ public class ServersAccessService implements DisposableBean, IServersAccessServi
 	}
 
 	@CrudLoggable(CrudLogLevel.DEBUG)
-	public DownloadFile getZip(List<String> dirs, SharedUserPortletParameters userParameters) throws IOException {	
+	public DownloadFile getZip(List<String> dirs, SharedUserPortletParameters userParameters) throws IOException {
 		File tmpFile = File.createTempFile("esup-stock-zip.", ".tmp");
 		// we call tmpFile.deleteOnExit so that ths tmp file will be deleted when jvm stops ...
 		// see also DownloadFile.finalize
 		tmpFile.deleteOnExit();
-		
+
 		FileOutputStream output = new FileOutputStream(tmpFile);
 		ZipOutputStream out = new ZipOutputStream(output);
 		for(String dir: dirs) {

--- a/src/main/java/org/esupportail/portlet/filemanager/services/evaluators/GroupEvaluator.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/evaluators/GroupEvaluator.java
@@ -1,0 +1,190 @@
+/**
+ * Licensed to EsupPortail under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * EsupPortail licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.esupportail.portlet.filemanager.services.evaluators;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.portlet.PortletRequest;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+/**
+ * @author GIP RECIA - Julien Gribonvald
+ * 14 oct. 2013
+ */
+public class GroupEvaluator implements IDriveAccessEvaluator, InitializingBean {
+
+	/**
+	 * Type operator to eavluate the list of evaluators.
+	 */
+	public enum Type {
+        OR,
+        AND,
+        NOT;
+    }
+
+	/** The logger. */
+	private static Log LOG = LogFactory.getLog(GroupEvaluator.class);
+
+	/** Operator type on evaluators list. */
+	private Type type = null;
+
+	/** List of evaluators to evaluate, must contains more than one evaluator. */
+	private List<IDriveAccessEvaluator> evaluators = new LinkedList<IDriveAccessEvaluator>();
+
+	/**
+	 * Contructor of the object GroupEvaluator.java.
+	 */
+	public GroupEvaluator() {
+		//TODO nothing
+	}
+
+	/**
+	 * Contructor of the object GroupEvaluator.java.
+	 * @param type Type operator to test evaluators. Null if only one evluator
+	 * @param evaluators List of Evaluation test.
+	 */
+	public GroupEvaluator(final String type, final List<IDriveAccessEvaluator> evaluators) {
+		this.type = Type.valueOf(type);
+		this.evaluators.addAll(evaluators);
+	}
+
+	/**
+	 * Do evaluation in function of type all evaluators
+	 * @param request Current PortletRequest
+	 * @return boolean value depending on evaluation.
+	 * @see org.esupportail.portlet.filemanager.services.evaluators.IDriveAccessEvaluator#isApplicable(PortletRequest)
+	 */
+	public boolean isApplicable(PortletRequest request) {
+		boolean rslt = false;
+        if (LOG.isDebugEnabled())
+            LOG.debug(" >>>> calling GroupEvaluator[" + this + ", op=" + type +
+                    "].isApplicable()");
+
+        if (type != null) {
+
+	        switch (this.type) {
+	        case OR: {
+	        	rslt = false;   // presume false in this case...
+	        	for(IDriveAccessEvaluator v : this.evaluators) {
+	        		if ( v.isApplicable( request ) ) {
+	        			rslt = true;
+	        			break;
+	        		}
+	        	}
+	        } break;
+
+	        case AND: {
+	        	rslt = true;   // presume true in this case...
+	        	for(IDriveAccessEvaluator v : this.evaluators) {
+	        		if ( v.isApplicable( request ) == false ) {
+	        			rslt = false;
+	        			break;
+	        		}
+	        	}
+	        } break;
+
+	        case NOT: {
+	        	rslt = false;   // presume false in this case... until later...
+	        	for(IDriveAccessEvaluator v : this.evaluators) {
+	        		if ( v.isApplicable( request ) ) {
+	        			rslt = true;
+	        			break;
+	        		}
+	        	}
+	        	rslt = !rslt;
+	        } break;
+	        }
+        }
+
+        if (LOG.isDebugEnabled())
+        	LOG.debug(" ---- GroupEvaluator[" + this + ", op=" + type
+        			+ "].isApplicable()=" + rslt);
+
+		return rslt;
+	}
+
+	/**
+	 * Getter of member type.
+	 * @return <code>Type</code> the attribute type
+	 */
+	public Type getType() {
+		return type;
+	}
+
+	/**
+	 * Setter of attribute type.
+	 * @param type the attribute type to set
+	 */
+	public void setType(final Type type) {
+		this.type = type;
+	}
+
+	/**
+	 * Setter of attribute type.
+	 * @param type the attribute type to set
+	 */
+	public void setType(final String type) {
+		this.type = Type.valueOf(type);
+	}
+
+	/**
+	 * Getter of member evaluators.
+	 * @return <code>List<IDriveAccessEvaluator></code> the attribute evaluators
+	 */
+	public List<IDriveAccessEvaluator> getEvaluators() {
+		return evaluators;
+	}
+
+	/**
+	 * Setter of attribute evaluators.
+	 * @param evaluators the attribute evaluators to set
+	 */
+	public void setEvaluators(final List<IDriveAccessEvaluator> evaluators) {
+		this.evaluators.addAll(evaluators);
+	}
+
+	/**
+	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
+	 */
+	public void afterPropertiesSet() throws Exception {
+		Assert.notNull(type, "The type of evaluator should not be null, values are [OR, AND, NOT]!");
+		Assert.notEmpty(evaluators, "The evaluator list can't be null or empty !");
+		Assert.isTrue((evaluators.size() > 1 && !Type.NOT.equals(type)) || (Type.NOT.equals(type) && evaluators.size() == 1),
+				"You need to set more than one evaluator when operator type != NOT or You need to set only one evaluator when operator type = NOT !");
+	}
+
+	/**
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("GroupEvaluator [type=");
+		builder.append(type);
+		builder.append(", evaluators=");
+		builder.append(evaluators);
+		builder.append("]");
+		return builder.toString();
+	}
+
+}

--- a/src/main/java/org/esupportail/portlet/filemanager/services/evaluators/IDriveAccessEvaluator.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/evaluators/IDriveAccessEvaluator.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to EsupPortail under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * EsupPortail licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ *
+ */
+package org.esupportail.portlet.filemanager.services.evaluators;
+
+import javax.portlet.PortletRequest;
+
+/**
+ * @author GIP RECIA - Julien Gribonvald
+ * 11 oct. 2013
+ */
+public interface IDriveAccessEvaluator {
+
+	boolean isApplicable(PortletRequest request);
+
+}

--- a/src/main/java/org/esupportail/portlet/filemanager/services/evaluators/ListUserAttributesEvaluatorEditor.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/evaluators/ListUserAttributesEvaluatorEditor.java
@@ -1,0 +1,174 @@
+/**
+ * Licensed to EsupPortail under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * EsupPortail licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.esupportail.portlet.filemanager.services.evaluators;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+/**
+ * A basic editor List< String > + params to List< UserAttributesEvaluator >.
+ * @author GIP RECIA - Gribonvald Julien
+ * 15 Oct 2013
+ */
+public class ListUserAttributesEvaluatorEditor implements FactoryBean, InitializingBean {
+
+    /** Logger.*/
+    private static final Log LOG = LogFactory.getLog(ListUserAttributesEvaluatorEditor.class);
+
+    /** */
+    private List<String> valueList;
+    /** */
+    private String userAttribute;
+    /** */
+    private String mode;
+	/** */
+    private List<UserAttributesEvaluator> editedProperties;
+
+    /**
+     * Constructor of ListUserRoleEvaluatorEditor.java.
+     */
+    public ListUserAttributesEvaluatorEditor() {
+        //block empty
+    }
+
+    /**
+     * Constructor of ListUserRoleEvaluatorEditor.java.
+     * @param arg0 list of values
+     * @param arg1 attribute name
+     * @param arg2 mode
+     */
+    public ListUserAttributesEvaluatorEditor(final List<String> arg0, final String arg1, final String arg2) {
+        this.setAsText(arg0, arg1, arg2);
+    }
+
+    /**
+     * @param arg0 list of values
+     * @param arg1 attribute name
+     * @param arg2 mode
+     * @throws IllegalArgumentException
+     * @see org.springframework.beans.propertyeditors.PropertiesEditor#setAsText(java.lang.String)
+     */
+    private void setAsText(final List<String> arg0, final String arg1, final String arg2) throws IllegalArgumentException {
+        List<UserAttributesEvaluator> list = new LinkedList<UserAttributesEvaluator>();
+        for (String value : arg0) {
+        	list.add(new UserAttributesEvaluator(value, arg1, arg2));
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("In : [" + arg0 + ", " + arg1 + ", " + arg2 + "] out : " + list.toString());
+        }
+        this.editedProperties = list;
+    }
+
+    /**
+     * @return <code>Object</code> Here returns a List of LDAP attributes names.
+     * @throws Exception
+     * @see org.springframework.beans.factory.FactoryBean#getObject()
+     */
+    public Object getObject() throws Exception {
+        // TODO Auto-generated method stub
+        return editedProperties;
+    }
+
+    /**
+     * @return <code>Class</code> The class name of the object returned.
+     * @see org.springframework.beans.factory.FactoryBean#getObjectType()
+     */
+    @SuppressWarnings("rawtypes")
+	public Class getObjectType() {
+        // TODO Auto-generated method stub
+        return List.class;
+    }
+
+    /**
+     * @return <code>boolean</code>
+     * @see org.springframework.beans.factory.FactoryBean#isSingleton()
+     */
+    public boolean isSingleton() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    /**
+     * @throws Exception
+     * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
+     */
+    public void afterPropertiesSet() throws Exception {
+        Assert.notEmpty(getValueList(), "The property valueList in class "
+                + this.getClass().getSimpleName() + " must not be null and not empty.");
+        Assert.hasLength(getUserAttribute(), "The property userAttribute in class "
+                + this.getClass().getSimpleName() + " must not be null and not empty.");
+        Assert.hasLength(getMode(), "The property mode in class "
+                + this.getClass().getSimpleName() + " must not be null and not empty.");
+
+        this.setAsText(getValueList(), getUserAttribute(), getMode());
+    }
+
+    /**
+	 * Getter of member valueList.
+	 * @return <code>List<String></code> the attribute valueList
+	 */
+	public List<String> getValueList() {
+		return valueList;
+	}
+
+	/**
+	 * Setter of attribute valueList.
+	 * @param valueList the attribute valueList to set
+	 */
+	public void setValueList(final List<String> valueList) {
+		this.valueList = valueList;
+	}
+
+	/**
+	 * Getter of member userAttribute.
+	 * @return <code>String</code> the attribute userAttribute
+	 */
+	public String getUserAttribute() {
+		return userAttribute;
+	}
+
+	/**
+	 * Setter of attribute userAttribute.
+	 * @param userAttribute the attribute userAttribute to set
+	 */
+	public void setUserAttribute(final String userAttribute) {
+		this.userAttribute = userAttribute;
+	}
+
+	/**
+	 * Getter of member mode.
+	 * @return <code>String</code> the attribute mode
+	 */
+	public String getMode() {
+		return mode;
+	}
+
+	/**
+	 * Setter of attribute mode.
+	 * @param mode the attribute mode to set
+	 */
+	public void setMode(final String mode) {
+		this.mode = mode;
+	}
+}

--- a/src/main/java/org/esupportail/portlet/filemanager/services/evaluators/ListUserMultivaluedAttributesEvaluatorEditor.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/evaluators/ListUserMultivaluedAttributesEvaluatorEditor.java
@@ -1,0 +1,174 @@
+/**
+ * Licensed to EsupPortail under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * EsupPortail licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.esupportail.portlet.filemanager.services.evaluators;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+/**
+ * A basic editor List< String > + params to List< UserMultivaluedAttributesEvaluator >.
+ * @author GIP RECIA - Gribonvald Julien
+ * 15 Oct. 2013
+ */
+public class ListUserMultivaluedAttributesEvaluatorEditor implements FactoryBean, InitializingBean {
+
+    /** Logger.*/
+    private static final Log LOG = LogFactory.getLog(ListUserMultivaluedAttributesEvaluatorEditor.class);
+
+    /** */
+    private List<String> valueList;
+    /** */
+    private String userAttribute;
+    /** */
+    private String mode;
+	/** */
+    private List<UserMultivaluedAttributesEvaluator> editedProperties;
+
+    /**
+     * Constructor of ListUserRoleEvaluatorEditor.java.
+     */
+    public ListUserMultivaluedAttributesEvaluatorEditor() {
+        //block empty
+    }
+
+    /**
+     * Constructor of ListUserRoleEvaluatorEditor.java.
+     * @param arg0 list of values
+     * @param arg1 attribute name
+     * @param arg2 mode
+     */
+    public ListUserMultivaluedAttributesEvaluatorEditor(final List<String> arg0, final String arg1, final String arg2) {
+        this.setAsText(arg0, arg1, arg2);
+    }
+
+    /**
+     * @param arg0 list of values
+     * @param arg1 attribute name
+     * @param arg2 mode
+     * @throws IllegalArgumentException
+     * @see org.springframework.beans.propertyeditors.PropertiesEditor#setAsText(java.lang.String)
+     */
+    private void setAsText(final List<String> arg0, final String arg1, final String arg2) throws IllegalArgumentException {
+        List<UserMultivaluedAttributesEvaluator> list = new LinkedList<UserMultivaluedAttributesEvaluator>();
+        for (String value : arg0) {
+        	list.add(new UserMultivaluedAttributesEvaluator(value, arg1, arg2));
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("In : [" + arg0 + ", " + arg1 + ", " + arg2 + "] out : " + list.toString());
+        }
+        this.editedProperties = list;
+    }
+
+    /**
+     * @return <code>Object</code> Here returns a List of LDAP attributes names.
+     * @throws Exception
+     * @see org.springframework.beans.factory.FactoryBean#getObject()
+     */
+    public Object getObject() throws Exception {
+        // TODO Auto-generated method stub
+        return editedProperties;
+    }
+
+    /**
+     * @return <code>Class</code> The class name of the object returned.
+     * @see org.springframework.beans.factory.FactoryBean#getObjectType()
+     */
+    @SuppressWarnings("rawtypes")
+	public Class getObjectType() {
+        // TODO Auto-generated method stub
+        return List.class;
+    }
+
+    /**
+     * @return <code>boolean</code>
+     * @see org.springframework.beans.factory.FactoryBean#isSingleton()
+     */
+    public boolean isSingleton() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    /**
+     * @throws Exception
+     * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
+     */
+    public void afterPropertiesSet() throws Exception {
+        Assert.notEmpty(getValueList(), "The property valueList in class "
+                + this.getClass().getSimpleName() + " must not be null and not empty.");
+        Assert.hasLength(getUserAttribute(), "The property userAttribute in class "
+                + this.getClass().getSimpleName() + " must not be null and not empty.");
+        Assert.hasLength(getMode(), "The property mode in class "
+                + this.getClass().getSimpleName() + " must not be null and not empty.");
+
+        this.setAsText(getValueList(), getUserAttribute(), getMode());
+    }
+
+    /**
+	 * Getter of member valueList.
+	 * @return <code>List<String></code> the attribute valueList
+	 */
+	public List<String> getValueList() {
+		return valueList;
+	}
+
+	/**
+	 * Setter of attribute valueList.
+	 * @param valueList the attribute valueList to set
+	 */
+	public void setValueList(final List<String> valueList) {
+		this.valueList = valueList;
+	}
+
+	/**
+	 * Getter of member userAttribute.
+	 * @return <code>String</code> the attribute userAttribute
+	 */
+	public String getUserAttribute() {
+		return userAttribute;
+	}
+
+	/**
+	 * Setter of attribute userAttribute.
+	 * @param userAttribute the attribute userAttribute to set
+	 */
+	public void setUserAttribute(final String userAttribute) {
+		this.userAttribute = userAttribute;
+	}
+
+	/**
+	 * Getter of member mode.
+	 * @return <code>String</code> the attribute mode
+	 */
+	public String getMode() {
+		return mode;
+	}
+
+	/**
+	 * Setter of attribute mode.
+	 * @param mode the attribute mode to set
+	 */
+	public void setMode(final String mode) {
+		this.mode = mode;
+	}
+}

--- a/src/main/java/org/esupportail/portlet/filemanager/services/evaluators/ListUserRoleEvaluatorEditor.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/evaluators/ListUserRoleEvaluatorEditor.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to EsupPortail under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * EsupPortail licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.esupportail.portlet.filemanager.services.evaluators;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+/**
+ * A basic editor List< String > to List< UserRoleEvaluator >.
+ * @author GIP RECIA - Gribonvald Julien
+ * 15 Oct 2013
+ */
+public class ListUserRoleEvaluatorEditor implements FactoryBean, InitializingBean {
+
+    /** Logger.*/
+    private static final Log LOG = LogFactory.getLog(ListUserRoleEvaluatorEditor.class);
+
+    /** */
+    private List<String> groupList;
+    /** */
+    private List<UserRoleEvaluator> editedProperties;
+
+    /**
+     * Constructor of ListUserRoleEvaluatorEditor.java.
+     */
+    public ListUserRoleEvaluatorEditor() {
+        //block empty
+    }
+
+    /**
+     * Constructor of ListUserRoleEvaluatorEditor.java.
+     * @param arg0
+     */
+    public ListUserRoleEvaluatorEditor(final List<String> arg0) {
+        this.setAsText(arg0);
+    }
+
+    /**
+     * @param arg0
+     * @throws IllegalArgumentException
+     * @see org.springframework.beans.propertyeditors.PropertiesEditor#setAsText(java.lang.String)
+     */
+    private void setAsText(final List<String> arg0) throws IllegalArgumentException {
+        List<UserRoleEvaluator> list = new LinkedList<UserRoleEvaluator>();
+        for (String grp : arg0) {
+        	list.add(new UserRoleEvaluator(grp));
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("String in : " + arg0 + " List out : " + list.toString());
+        }
+        this.editedProperties = list;
+    }
+
+    /**
+     * @return <code>Object</code> Here returns a List of LDAP attributes names.
+     * @throws Exception
+     * @see org.springframework.beans.factory.FactoryBean#getObject()
+     */
+    public Object getObject() throws Exception {
+        // TODO Auto-generated method stub
+        return editedProperties;
+    }
+
+    /**
+     * @return <code>Class</code> The class name of the object returned.
+     * @see org.springframework.beans.factory.FactoryBean#getObjectType()
+     */
+    @SuppressWarnings("rawtypes")
+	public Class getObjectType() {
+        // TODO Auto-generated method stub
+        return List.class;
+    }
+
+    /**
+     * @return <code>boolean</code>
+     * @see org.springframework.beans.factory.FactoryBean#isSingleton()
+     */
+    public boolean isSingleton() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    /**
+     * @throws Exception
+     * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
+     */
+    public void afterPropertiesSet() throws Exception {
+        Assert.notEmpty(getGroupList(), "The property groupList in class "
+                + this.getClass().getSimpleName() + " must not be null and not empty.");
+
+        this.setAsText(getGroupList());
+    }
+
+    /**
+     * Getter du membre groupList.
+     * @return <code>String</code> le membre groupList.
+     */
+    public List<String> getGroupList() {
+        return groupList;
+    }
+
+    /**
+     * Setter du membre groupList.
+     * @param groupList la nouvelle valeur du membre groupList.
+     */
+    public void setGroupList(final List<String> groupList) {
+        this.groupList = groupList;
+    }
+
+
+
+}

--- a/src/main/java/org/esupportail/portlet/filemanager/services/evaluators/PreferenceEvaluator.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/evaluators/PreferenceEvaluator.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to EsupPortail under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * EsupPortail licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.esupportail.portlet.filemanager.services.evaluators;
+
+import javax.portlet.PortletRequest;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+/**
+ * @author GIP RECIA - Julien Gribonvald
+ * 14 oct. 2013
+ */
+public class PreferenceEvaluator implements IDriveAccessEvaluator, InitializingBean {
+
+	/** The portlet preference attribute. */
+	private String attribute;
+	/** The portlet preference value. */
+	private String value;
+
+	/**
+	 * Contructor of the object PreferenceEvaluator.java.
+	 */
+	public PreferenceEvaluator() {
+		super();
+	}
+
+	/**
+	 * Contructor of the object PreferenceEvaluator.java.
+	 * @param attribute The portlet Attribute to get for evaluation.
+	 * @param value The value to compare.
+	 */
+	public PreferenceEvaluator(final String attribute, final String value) {
+		this.attribute = attribute;
+		this.value = value;
+	}
+
+	/**
+	 * @see org.esupportail.portlet.filemanager.services.evaluators.IDriveAccessEvaluator#isApplicable(javax.portlet.PortletRequest)
+	 */
+	public boolean isApplicable(PortletRequest request) {
+		final String pref = request.getPreferences().getValue(attribute, null);
+		if (pref != null && pref.equals(value) )
+			return true;
+		return false;
+	}
+
+	/**
+	 * Getter of member attribute.
+	 * @return <code>String</code> the attribute attribute
+	 */
+	public String getAttribute() {
+		return attribute;
+	}
+
+	/**
+	 * Setter of attribute attribute.
+	 * @param attribute the attribute attribute to set
+	 */
+	public void setAttribute(final String attribute) {
+		this.attribute = attribute;
+	}
+
+	/**
+	 * Getter of member value.
+	 * @return <code>String</code> the attribute value
+	 */
+	public String getValue() {
+		return value;
+	}
+
+	/**
+	 * Setter of attribute value.
+	 * @param value the attribute value to set
+	 */
+	public void setValue(final String value) {
+		this.value = value;
+	}
+
+	/**
+	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
+	 */
+	public void afterPropertiesSet() throws Exception {
+		Assert.hasLength(attribute, "The portlet Attribute to evaluate must be set !");
+		Assert.hasLength(value, "The value to compare must be set !");
+	}
+
+	/**
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("PreferenceEvaluator [attribute=");
+		builder.append(attribute);
+		builder.append(", value=");
+		builder.append(value);
+		builder.append("]");
+		return builder.toString();
+	}
+}

--- a/src/main/java/org/esupportail/portlet/filemanager/services/evaluators/UserAttributesEvaluator.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/evaluators/UserAttributesEvaluator.java
@@ -1,0 +1,196 @@
+/**
+ * Licensed to EsupPortail under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * EsupPortail licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.esupportail.portlet.filemanager.services.evaluators;
+
+import java.util.Map;
+
+import javax.portlet.PortletRequest;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+/**
+ * @author GIP RECIA - Julien Gribonvald
+ * 14 oct. 2013
+ */
+public class UserAttributesEvaluator implements IDriveAccessEvaluator, InitializingBean {
+
+	public enum Mode {
+		CONTAINS,
+		EQUALS,
+		STARTS_WITH,
+		ENDS_WITH,
+		EXISTS,
+		MATCH,
+	}
+
+	/** Logger. */
+	private static final Log log =  LogFactory.getLog(UserAttributesEvaluator.class);
+
+	/** The portlet preference attribute. */
+	private String attribute;
+	/** The portlet preference value. */
+	private String value;
+	/** The mode to evaluate the attribute. */
+	private Mode mode;
+
+	/**
+	 * Contructor of the object UserAttributesEvaluator.java.
+	 */
+	public UserAttributesEvaluator() {
+		super();
+	}
+
+	/**
+	 * Contructor of the object UserAttributesEvaluator.java.
+	 * @param mode The String comparator type.
+	 */
+	public UserAttributesEvaluator(final String mode) {
+		this.mode = Mode.valueOf(mode);
+	}
+
+	/**
+	 * Contructor of the object UserAttributesEvaluator.java.
+	 * @param attribute The User Attribute to get for evaluation.
+	 * @param value The value to compare.
+	 * @param mode The String comparator type.
+	 */
+	public UserAttributesEvaluator(final String attribute, final String value, final String mode) {
+		this.attribute = attribute;
+		this.value = value;
+		this.mode = Mode.valueOf(mode);
+	}
+
+	/**
+	 * @see org.esupportail.portlet.filemanager.services.evaluators.IDriveAccessEvaluator#isApplicable(javax.portlet.PortletRequest)
+	 */
+	public boolean isApplicable(PortletRequest request) {
+		final Map<String, String> userInfos = (Map<String, String>) request.getAttribute(PortletRequest.USER_INFO);
+		if (userInfos == null)
+			return false;
+
+		final String attrib = userInfos.get(attribute);
+
+		if (log.isDebugEnabled()) {
+			log.debug("value=" + value + ",mode=" + mode + ",attrib=" + attrib);
+		}
+
+		// for tests other than 'exists' the attribute must be defined
+		if ( attrib == null && !Mode.EXISTS.equals(mode) )
+			return false;
+
+		if ( Mode.EQUALS.equals(mode) )
+			return attrib.equals( value );
+		if ( Mode.EXISTS.equals(mode) )
+			return attrib != null;
+		if ( Mode.STARTS_WITH.equals(mode) )
+			return attrib.startsWith( value );
+		if ( Mode.ENDS_WITH.equals(mode) )
+			return attrib.endsWith( value );
+		if ( Mode.CONTAINS.equals(mode) )
+			return (attrib.indexOf( value ) != -1 );
+		if ( Mode.MATCH.equals(mode) )
+			return attrib.matches(value);
+		// will never get here
+		return false;
+	}
+
+	/**
+	 * Getter of member attribute.
+	 * @return <code>String</code> the attribute attribute
+	 */
+	public String getAttribute() {
+		return attribute;
+	}
+
+	/**
+	 * Setter of attribute attribute.
+	 * @param attribute the attribute attribute to set
+	 */
+	public void setAttribute(final String attribute) {
+		this.attribute = attribute;
+	}
+
+	/**
+	 * Getter of member value.
+	 * @return <code>String</code> the attribute value
+	 */
+	public String getValue() {
+		return value;
+	}
+
+	/**
+	 * Setter of attribute value.
+	 * @param value the attribute value to set
+	 */
+	public void setValue(final String value) {
+		this.value = value;
+	}
+
+	/**
+	 * Getter of member mode.
+	 * @return <code>Mode</code> the attribute mode
+	 */
+	public Mode getMode() {
+		return mode;
+	}
+
+	/**
+	 * Setter of attribute mode.
+	 * @param mode the attribute mode to set
+	 */
+	public void setMode(final Mode mode) {
+		this.mode = mode;
+	}
+
+	/**
+	 * Setter of attribute mode.
+	 * @param mode the attribute mode to set
+	 */
+	public void setMode(final String mode) {
+		this.mode = Mode.valueOf(mode);
+	}
+
+	/**
+	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
+	 */
+	public void afterPropertiesSet() throws Exception {
+		Assert.hasLength(attribute, "The portlet Attribute to evaluate must be set !");
+		Assert.hasLength(value, "The value to compare must be set !");
+		Assert.notNull(mode, "The comparison mode must not be null !");
+	}
+
+	/**
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("UserAttributesEvaluator [attribute=");
+		builder.append(attribute);
+		builder.append(", value=");
+		builder.append(value);
+		builder.append(", mode=");
+		builder.append(mode);
+		builder.append("]");
+		return builder.toString();
+	}
+
+}

--- a/src/main/java/org/esupportail/portlet/filemanager/services/evaluators/UserMultivaluedAttributesEvaluator.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/evaluators/UserMultivaluedAttributesEvaluator.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to EsupPortail under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * EsupPortail licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.esupportail.portlet.filemanager.services.evaluators;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.portlet.PortletRequest;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.InitializingBean;
+
+/**
+ * @author GIP RECIA - Julien Gribonvald
+ * 14 oct. 2013
+ */
+public class UserMultivaluedAttributesEvaluator extends UserAttributesEvaluator implements InitializingBean {
+
+	/** Logger. */
+	private static final Log log =  LogFactory.getLog(UserMultivaluedAttributesEvaluator.class);
+
+	/**
+	 * Contructor of the object UserMultivaluedAttributesEvaluator.java.
+	 */
+	public UserMultivaluedAttributesEvaluator() {
+		super();
+	}
+
+	/**
+	 * Contructor of the object UserMultivaluedAttributesEvaluator.java.
+	 * @param attribute The User Attribute to get for evaluation.
+	 * @param value The value to compare.
+	 * @param mode The String comparator type.
+	 */
+	public UserMultivaluedAttributesEvaluator(final String attribute, final String value, final String mode) {
+		super(attribute, value, mode);
+	}
+
+	/**
+	 * @see org.esupportail.portlet.filemanager.services.evaluators.IDriveAccessEvaluator#isApplicable(javax.portlet.PortletRequest)
+	 */
+	@Override
+	public boolean isApplicable(PortletRequest request) {
+		final Map<String, List<String>> userInfos = (Map<String, List<String>>) request.getAttribute("org.jasig.portlet.USER_INFO_MULTIVALUED");
+		if (userInfos == null)
+			return false;
+		final List<String> attribs = userInfos.get(this.getAttribute());
+
+		if (log.isDebugEnabled()) {
+			log.debug("value=" + this.getValue() + ",mode=" + this.getMode() + ",attrib=" + attribs);
+		}
+
+		// for tests other than 'exists' the attribute must be defined
+		if ( (attribs == null || attribs.isEmpty()) && !Mode.EXISTS.equals(this.getMode()) )
+			return false;
+
+		if ( Mode.EQUALS.equals(this.getMode()) )
+			return attribs.contains( this.getValue() );
+		if ( Mode.EXISTS.equals(this.getMode()) )
+			return attribs != null && !attribs.isEmpty();
+		if ( Mode.STARTS_WITH.equals(this.getMode()) ) {
+			for ( String val : attribs ) {
+				if (val.startsWith(this.getValue()))
+					return true;
+			}
+		}
+		if ( Mode.ENDS_WITH.equals(this.getMode()) ) {
+			for ( String val : attribs ) {
+				if (val.endsWith(this.getValue()))
+					return true;
+			}
+		}
+		if ( Mode.CONTAINS.equals(this.getMode()) ) {
+			for ( String val : attribs ) {
+				if (val.indexOf( this.getValue() ) != -1 )
+					return true;
+			}
+		}
+		if ( Mode.MATCH.equals(this.getMode()) ) {
+			for ( String val : attribs ) {
+				if (val.matches( this.getValue() ) )
+					return true;
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/src/main/java/org/esupportail/portlet/filemanager/services/evaluators/UserRoleEvaluator.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/evaluators/UserRoleEvaluator.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to EsupPortail under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * EsupPortail licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.esupportail.portlet.filemanager.services.evaluators;
+
+import javax.portlet.PortletRequest;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+/**
+ * @author GIP RECIA - Julien Gribonvald
+ * 14 oct. 2013
+ */
+public class UserRoleEvaluator implements IDriveAccessEvaluator, InitializingBean {
+
+	/** The portlet group value. */
+	private String group;
+
+	/**
+	 * Contructor of the object UserRoleEvaluator.java.
+	 */
+	public UserRoleEvaluator() {
+		// empty block
+	}
+
+	/**
+	 * Contructor of the object UserRoleEvaluator.java.
+	 * @param group The group name to evaluate.
+	 */
+	public UserRoleEvaluator(final String group) {
+		this.group = group;
+	}
+
+	/**
+	 * @see org.esupportail.portlet.filemanager.services.evaluators.IDriveAccessEvaluator#isApplicable(javax.portlet.PortletRequest)
+	 */
+	public boolean isApplicable(PortletRequest request) {
+		if (request.isUserInRole(group))
+			return true;
+		return false;
+	}
+
+	/**
+	 * Getter of member group.
+	 * @return <code>String</code> the attribute group
+	 */
+	public String getGroup() {
+		return group;
+	}
+
+	/**
+	 * Setter of attribute group.
+	 * @param group the attribute group to set
+	 */
+	public void setGroup(final String group) {
+		this.group = group;
+	}
+
+	/**
+	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
+	 */
+	public void afterPropertiesSet() throws Exception {
+		Assert.hasLength(group, "The group to compare must be set !");
+	}
+
+	/**
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("UserRoleEvaluator [group=");
+		builder.append(group);
+		builder.append("]");
+		return builder.toString();
+	}
+}

--- a/src/main/webapp/WEB-INF/context/drives.xml
+++ b/src/main/webapp/WEB-INF/context/drives.xml
@@ -18,8 +18,8 @@
     limitations under the License.
 
 -->
-<beans xmlns="http://www.springframework.org/schema/beans" 
-       xmlns:util="http://www.springframework.org/schema/util"    
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:util="http://www.springframework.org/schema/util"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
 			   http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd">
@@ -65,37 +65,37 @@
       </bean>
     </entry>
   </util:map>
-  
+
   <!-- Here it's the definition of a FSAccess bean : here we use a 'VfsAccessImpl'
        This implementation of drive uses Apache Commons VFS.
-       So you can see uri format here : 
+       So you can see uri format here :
        http://commons.apache.org/vfs/filesystems.html
        Take care, by default 'mvn package' doesn't provide cifs or webdav support.
-       If you want to use cifs or webdav, 
+       If you want to use cifs or webdav,
           * (*deprecated* : before esup-filemanager 1.1.0 you should use the maven profil named vfs-sandbox :
        'mvn package -P vfs-sandbox' / 'mvn jetty:run -P vfs-sandbox')
           * you  should now use instead SardineAccessImpl (webdav) or CifsAccessImpl (cifs) - see examples below
-      
-       You can choose as authentication 
+
+       You can choose as authentication
        * no authentication
        * simple authentication : we give username/password in this config file for all
-       * trusted authentication : we give an userInfo4Username parameter that retrieve username from portal 
+       * trusted authentication : we give an userInfo4Username parameter that retrieve username from portal
        * form authentication : we will ask username/password to the user when accessing this drive
-       * cas authentication : we're using proxy cas 
-       
+       * cas authentication : we're using proxy cas
+
        Toto uses a simple authentication : all people use the same connection with the same username/password
        Toto is displayed only to members of pags.mon-univ
-       
-       This drive is displayed only for people who belong to the group "pags.mon-univ" 
+
+       This drive is displayed only for people who belong to the group "pags.mon-univ"
    -->
   <bean class="org.esupportail.portlet.filemanager.services.vfs.VfsAccessImpl" lazy-init="true">
     <property name="driveName" value="Toto"/>
     <property name="icon" value="/esup-filemanager/img/drives/tux.png" />
     <property name="uri" value="sftp://stock-2.mon-univ.fr/"/>
-    <property name="memberOfAny">
-      <list>
-		<value>pags.mon-univ</value>
-      </list>
+    <property name="evaluator">
+    	<bean class="org.esupportail.portlet.filemanager.services.evaluators.UserRoleEvaluator" >
+    		<property name="group" value="pags.mon-univ" />
+    	</bean>
     </property>
     <property name="userAuthenticatorService" ref="simpleUserAuthenticationService"/>
     <property name="resourceUtils" ref="resourceUtils"/>
@@ -106,10 +106,10 @@
     <property name="password" value="toto"/>
   </bean>
 
-  
 
-  <!-- bob doesn't use authentication 
-  bob is displayed to all people 
+
+  <!-- bob doesn't use authentication
+  bob is displayed to all people
   bob has a contextToken property : if we set up a contextToken parameter with value justbob when publishing the portlet in the portal,
   only drives with a contextToken equals to justbob (like ebob for example here) will be displayed.
   -->
@@ -117,26 +117,52 @@
     <property name="driveName" value="bob"/>
     <property name="icon" value="/esup-filemanager/img/drives/root.png" />
     <property name="uri" value="file:///"/>
-    <property name="contextToken" value="justbob"/>
+    <property name="evaluator">
+    	<bean class="org.esupportail.portlet.filemanager.services.evaluators.PreferenceEvaluator" >
+    		<property name ="attribute" value="contextToken"/>
+    		<property name ="value" value="justbob"/>
+    	</bean>
+    </property>
     <property name="resourceUtils" ref="resourceUtils"/>
   </bean>
-  
-  
- <!-- Stock2 uses a form authentication 
+
+
+ <!-- Stock2 uses a form authentication
       uri contains a token @uid@ : it will be replaced with the value of uid attribute that will be gived by portal
       (so we should modify portlet.xml to ask portal to give this "uid" attribute user)
       you can use all attributes user provided by portal here like this
-      you can also use the special token @form_username@ which is replaced with the value of the form username 
+      you can also use the special token @form_username@ which is replaced with the value of the form username
       that can be gived by the user (when the access requires a form user authentication)
   -->
   <bean class="org.esupportail.portlet.filemanager.services.vfs.VfsAccessImpl" scope="session" lazy-init="true">
     <property name="driveName" value="Stock2"/>
     <property name="icon" value="/esup-filemanager/img/drives/root.png" />
     <property name="uri" value="sftp://stock-2.mon-univ.fr/home/@uid@/"/>
-    <property name="memberOfAny">
-      <list>
-		<value>pags.mon-univ</value>
-      </list>
+    <property name="evaluator">
+    	<bean class="org.esupportail.portlet.filemanager.services.evaluators.GroupEvaluator" >
+ 	  		<property name="type" value="AND"/>
+ 	   		<property name="evaluators">
+ 	   			<list>
+    				<bean class="org.esupportail.portlet.filemanager.services.evaluators.GroupEvaluator" >
+			 	  		<property name="type" value="OR"/>
+			 	   		<property name="evaluators">
+							<bean class="org.esupportail.portlet.filemanager.services.evaluators.ListUserRoleEvaluatorEditor">
+								<property name="groupList">
+			 	   					<list>
+					    				<value>pags.composante3</value>
+			    						<value>pags.composante5</value>
+			    					</list>
+			    				</property>
+			    			</bean>
+			    		</property>
+			    	</bean>
+    				<bean class="org.esupportail.portlet.filemanager.services.evaluators.PreferenceEvaluator" >
+    					<property name ="attribute" value="contextToken"/>
+    					<property name ="value" value="justbob"/>
+    				</bean>
+	    		</list>
+    		</property>
+    	</bean>
     </property>
     <property name="userAuthenticatorService" ref="formUserAuthenticationService"/>
     <property name="resourceUtils" ref="resourceUtils"/>
@@ -147,19 +173,19 @@
 	scope="session">
     <property name="userInfo4Username" value="uid"/>
   </bean>
-  
+
   <!-- here a trusted authentication (password is the same for all) - note that we don't use it in drives examples -->
   <bean name="trustedUserAuthenticationService" class="org.esupportail.portlet.filemanager.services.auth.UserPasswordAuthenticatorService"
 	scope="session">
     <property name="userInfo4Username" value="uid"/>
     <property name="password" value="commonTrustedPassword4All"/>
   </bean>
-  
-  <!-- Stock2Cas uses proxy cas authentication 
+
+  <!-- Stock2Cas uses proxy cas authentication
        sftpSetUserDirIsRoot is set to use user directory as root
-              
-       Note also this drive is displayed only for people who has 
-       attribute affiliation matches (regex) (.*)student(.*) 
+
+       Note also this drive is displayed only for people who has
+       attribute affiliation matches (regex) (.*)student(.*)
        and compsante = unecomposante ...
   -->
   <bean class="org.esupportail.portlet.filemanager.services.vfs.VfsAccessImpl" scope="session" lazy-init="true">
@@ -167,12 +193,25 @@
     <property name="icon" value="/esup-filemanager/img/drives/root.png" />
     <property name="uri" value="sftp://stock-2.mon-univ.fr/"/>
     <property name="sftpSetUserDirIsRoot" value="true"/>
-    <property name="hasAttributs">
-		<map>
-			<entry key="affiliation" value="(.*)student(.*)"/>
-			<entry key="compsante" value="unecomposante"/>
-		</map>
-	</property>
+    <property name="evaluator">
+    	<bean class="org.esupportail.portlet.filemanager.services.evaluators.GroupEvaluator" >
+    		<property name="type" value="AND" />
+    		<property name="evaluators">
+    			<list>
+   					<bean class="org.esupportail.portlet.filemanager.services.evaluators.UserAttributesEvaluator">
+   						<property name="attribute" value="affiliation" />
+   						<property name="value" value="(.*)student(.*)" />
+   						<property name="mode" value="MATCH" />
+   					</bean>
+   					<bean class="org.esupportail.portlet.filemanager.services.evaluators.UserAttributesEvaluator">
+   						<property name="attribute" value="composante" />
+   						<property name="value" value="unecomposante" />
+   						<property name="mode" value="EQUALS" />
+   					</bean>
+    			</list>
+    		</property>
+    	</bean>
+    </property>
     <property name="userAuthenticatorService" ref="casUserAuthenticationService"/>
     <property name="resourceUtils" ref="resourceUtils"/>
   </bean>
@@ -199,7 +238,7 @@
   </bean>
 
 
- <!-- Definition of a FSAccess bean : here we have a 'SardineAccessImpl' to use a webdav shared folder -->                          
+ <!-- Definition of a FSAccess bean : here we have a 'SardineAccessImpl' to use a webdav shared folder -->
   <bean class="org.esupportail.portlet.filemanager.services.sardine.SardineAccessImpl" scope="session" lazy-init="true">
     <property name="driveName" value="DAV Ex"/>
     <property name="icon" value="/esup-filemanager/img/drives/drive_network.png" />
@@ -212,7 +251,7 @@
         scope="session"/>
 
 
- <!-- Definition of a FSAccess bean : here we have a 'CifsAccessImpl' to use a cifs shared folder -->                          
+ <!-- Definition of a FSAccess bean : here we have a 'CifsAccessImpl' to use a cifs shared folder -->
   <bean class="org.esupportail.portlet.filemanager.services.cifs.CifsAccessImpl" scope="session" lazy-init="true">
     <property name="driveName" value="CIFS Ex"/>
     <property name="icon" value="/esup-filemanager/img/drives/drive_network.png" />
@@ -228,7 +267,7 @@
     <prop key="jcifs.smb.client.disablePlainTextPasswords">true</prop>
     <prop key="jcifs.smb.client.responseTimeout">40000</prop>
   </util:properties>
-  
+
   <bean id="formUAS4" class="org.esupportail.portlet.filemanager.services.auth.FormUserPasswordAuthenticatorService"
 	scope="session">
     <property name="userInfo4Username" value="ENTPersonLogin"/>
@@ -238,16 +277,16 @@
 
 
   <!-- Here it's the definition of a FSAccess bean : here we have a 'TrustedCmisAccessImpl'
-       This implementation of drive (using CMIS like FileSystem protocol) has been (at the moment) 
+       This implementation of drive (using CMIS like FileSystem protocol) has been (at the moment)
        tested only with Nuxeo (nuxeo-dm-5.4.0-tomcat)
-       Like for others, you can choose as authentication 
+       Like for others, you can choose as authentication
        * no authentication
        * simple authentication : we give username/password in this config file for all
        * form authentication : we will ask username/password to the user when accessing this drive
-       * cas authentication : we're using proxy cas 
-       You can also use a "shibboleth like" authentication : 
-       esup-filemanager send request with specific http headers 
-       so that the Nuxeo "nuxeo-platform-login-shibboleth" plugin (for nuxeo) authenticates esup-filemanager 
+       * cas authentication : we're using proxy cas
+       You can also use a "shibboleth like" authentication :
+       esup-filemanager send request with specific http headers
+       so that the Nuxeo "nuxeo-platform-login-shibboleth" plugin (for nuxeo) authenticates esup-filemanager
        trusting http headers.
   -->
   <bean class="org.esupportail.portlet.filemanager.services.opencmis.TrustedCmisAccessImpl" scope="session" lazy-init="true">
@@ -261,18 +300,18 @@
     <property name="rootPath" value="/default-domain/workspaces"/>
     <!--property name="userAuthenticatorService" ref="cmisSimpleUserAuthenticationService"/-->
     <!--property name="userAuthenticatorService" ref="cmisFormUserAuthenticationService"/-->
-   
+
    	<!-- You can use Nuxeo PORTAL_AUTH setting nuxeoPortalSsoSecretKey and nuxeoPortalSsoUsernameAttribute -->
     <!--property name="nuxeoPortalSsoSecretKey" value="nuxeo5secretkey"/>
     <property name="nuxeoPortalSsoUsernameAttribute" value="uid"/-->
-    
+
     <!--  userinfosHttpheadersMap : it is used only in portlet mode beacause setinfos must be available -->
     <property name="userinfosHttpheadersMap">
       <map>
 		<entry key="eppn" value="uid"/>
 		<entry key="affiliation" value="affiliation"/>
       </map>
-    </property>		
+    </property>
     <!-- staticHttpheadersMap : you can use it in servlet mode for testing
 	 (and portlet mode but for portlet mode use instead userinfosHttpheadersMap) -->
     <property name="staticHttpheadersMap">
@@ -281,25 +320,32 @@
 		<entry key="affiliation" value="member@mon-univ.fr"/>
       </map>
     </property>
-    <property name="memberOfAny">
-      <list>
-		<value>pags.mon-univ</value>
-      </list>
-    </property>
+    <property name="evaluator">
+	    <bean class="org.esupportail.portlet.filemanager.services.evaluators.GroupEvaluator" >
+	  		<property name="type" value="NOT"/>
+	   		<property name="evaluators">
+	   			<list>
+	  				<bean class="org.esupportail.portlet.filemanager.services.evaluators.UserRoleEvaluator" >
+	  					<property name="group" value="pags.composante3" />
+	  				</bean>
+	  			</list>
+	  		</property>
+	  	</bean>
+	</property>
     <property name="resourceUtils" ref="resourceUtils"/>
   </bean>
 
-  <!-- by default, we don't use it here : no reference is made on Cmis drive : it's commented -->  
+  <!-- by default, we don't use it here : no reference is made on Cmis drive : it's commented -->
   <bean name="cmisSimpleUserAuthenticationService" class="org.esupportail.portlet.filemanager.services.auth.UserPasswordAuthenticatorService">
     <property name="username" value="Administrator"/>
     <property name="password" value="Administrator"/>
   </bean>
 
-  <!-- by default, we don't use it here : no reference is made on Cmis drive : it's commented -->  
+  <!-- by default, we don't use it here : no reference is made on Cmis drive : it's commented -->
   <bean name="cmisFormUserAuthenticationService" class="org.esupportail.portlet.filemanager.services.auth.FormUserPasswordAuthenticatorService"
 	scope="session">
     <property name="userInfo4Username" value="eppn"/>
   </bean>
-  
-  
+
+
 </beans>


### PR DESCRIPTION
Using bean injection to make composition of evaluators to check user's drives access, more configurable and we can easily play with intersection/exclusion/union between User roles / User attributes (also multivalued attributes in uPortal) et preference context.
