### PR TITLE
Issue #20 : Key pressed Delete delete the file being renamed

### DIFF
--- a/src/main/webapp/js/esup-stock.js
+++ b/src/main/webapp/js/esup-stock.js
@@ -2175,6 +2175,7 @@ $.authenticate = function(dir, username, password) { authenticate(dir, username,
       break;
     case 46:
       console.log("Suppr key pressed");
+      if ($(".renameSpan:not(:hidden)").length) {return;}
       deleteFiles();
       break;    
     case 113:


### PR DESCRIPTION
Is this fix is suffisant ? Because when renaming a file we can do other actions, like select an other file, folder or doing other actions, so when renaming a file should we disable other actions ?

PR via edit on github !
