### PR TITLE
Fix: NPE when no userAuthenticatorService set

### DIFF
--- a/src/main/java/org/esupportail/portlet/filemanager/services/FsAccess.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/FsAccess.java
@@ -177,7 +177,7 @@ public abstract class FsAccess {
 	}
 
 	public boolean formAuthenticationRequired(SharedUserPortletParameters userParameters) {
-		if(this.userAuthenticatorService.formAuthenticationNeeded(userParameters)) {
+		if(this.userAuthenticatorService != null && this.userAuthenticatorService.formAuthenticationNeeded(userParameters)) {
 			if(this.userAuthenticatorService.getUserPassword(userParameters) == null || this.userAuthenticatorService.getUserPassword(userParameters).getPassword() == null || this.userAuthenticatorService.getUserPassword(userParameters).getPassword().length() == 0) {
 				this.userAuthenticatorService.initialize(userParameters);
 				return true;

--- a/src/main/java/org/esupportail/portlet/filemanager/services/FsAccess.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/FsAccess.java
@@ -178,7 +178,7 @@ public abstract class FsAccess {
 
 	public boolean formAuthenticationRequired(SharedUserPortletParameters userParameters) {
 		if(this.userAuthenticatorService != null && this.userAuthenticatorService.formAuthenticationNeeded(userParameters)) {
-			if(this.userAuthenticatorService.getUserPassword(userParameters) == null || this.userAuthenticatorService.getUserPassword(userParameters).getPassword() == null || this.userAuthenticatorService.getUserPassword(userParameters).getPassword().length() == 0) {
+			if (this.userAuthenticatorService.getUserPassword(userParameters) == null || this.userAuthenticatorService.getUserPassword(userParameters).getPassword() == null || this.userAuthenticatorService.getUserPassword(userParameters).getPassword().length() == 0) {
 				this.userAuthenticatorService.initialize(userParameters);
 				return true;
 			}

--- a/src/main/java/org/esupportail/portlet/filemanager/services/FsAccess.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/services/FsAccess.java
@@ -177,7 +177,7 @@ public abstract class FsAccess {
 	}
 
 	public boolean formAuthenticationRequired(SharedUserPortletParameters userParameters) {
-		if(this.userAuthenticatorService != null && this.userAuthenticatorService.formAuthenticationNeeded(userParameters)) {
+		if (this.userAuthenticatorService != null && this.userAuthenticatorService.formAuthenticationNeeded(userParameters)) {
 			if (this.userAuthenticatorService.getUserPassword(userParameters) == null || this.userAuthenticatorService.getUserPassword(userParameters).getPassword() == null || this.userAuthenticatorService.getUserPassword(userParameters).getPassword().length() == 0) {
 				this.userAuthenticatorService.initialize(userParameters);
 				return true;


### PR DESCRIPTION
a userAuthenticatorService is not a mandatory property, and when it's not set the user don't need to be anthenticated.
This change avoid a NPE for a such case.