### PR TITLE
build: move to esup portail group, which still has maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -493,9 +493,9 @@
 
 
       <plugin>
-        <groupId>net.jlehtinen.portlet</groupId>
+        <groupId>org.esupportail</groupId>
         <artifactId>portlet-prototyping-maven-plugin</artifactId>
-        <version>0.9</version>
+        <version>0.11</version>
         <configuration>
 
           <!-- Comma-separated list of portlets to be prototyped -->


### PR DESCRIPTION
resolves issue renovate flagged, screenshot below

![Screenshot 2022-10-05 at 11-59-04 Dependency Dashboard · Issue #89 · uPortal-Project_esup-filemanager](https://user-images.githubusercontent.com/3107513/194140638-3310870e-bd44-4e89-b966-b67c1f873e91.png)
