### PR TITLE
fix: provide way to do dispatch.include for Ajax ResourceRequest on views

### DIFF
--- a/src/main/java/org/esupportail/portlet/filemanager/portlet/CustomDispatcherPortlet.java
+++ b/src/main/java/org/esupportail/portlet/filemanager/portlet/CustomDispatcherPortlet.java
@@ -1,0 +1,27 @@
+package org.esupportail.portlet.filemanager.portlet;
+
+import javax.portlet.MimeResponse;
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletRequestDispatcher;
+
+import org.springframework.web.portlet.DispatcherPortlet;
+
+public class CustomDispatcherPortlet extends DispatcherPortlet {
+
+    /**
+     * Perform a dispatch on the given PortletRequestDispatcher.
+     * <p>The default implementation uses a forward for resource requests
+     * and an include for render requests.
+     * @param dispatcher the PortletRequestDispatcher to use
+     * @param request current portlet render/resource request
+     * @param response current portlet render/resource response
+     * @throws Exception if there's a problem performing the dispatch
+     */
+    @Override
+    protected void doDispatch(PortletRequestDispatcher dispatcher, PortletRequest request, MimeResponse response)
+            throws Exception {
+        // fix code as getting this problem https://github.com/spring-projects/spring-framework/issues/15417
+        // TODO need to rebuild the portlet => WebComponent + API to fix
+        dispatcher.include(request, response);
+    }
+}

--- a/src/main/webapp/WEB-INF/portlet.xml
+++ b/src/main/webapp/WEB-INF/portlet.xml
@@ -19,124 +19,124 @@
 
 -->
 <portlet-app
-    xmlns="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd"
-    version="1.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd
+        xmlns="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd"
+        version="1.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd
                         http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd">
 
-    <portlet>
-        <portlet-name>esup-filemanager</portlet-name>
-        <display-name xml:lang="fr">esup-filemanager</display-name>
-        <portlet-class>org.springframework.web.portlet.DispatcherPortlet</portlet-class>
-        <init-param>
-            <name>contextConfigLocation</name>
-            <value>WEB-INF/context/portlet/portletContext.xml</value>
-        </init-param>
-        <expiration-cache>0</expiration-cache>
-        <supports>
-            <mime-type>text/html</mime-type> 
-            <portlet-mode>VIEW</portlet-mode>
-            <portlet-mode>EDIT</portlet-mode>
-            <portlet-mode>HELP</portlet-mode>
-            <portlet-mode>ABOUT</portlet-mode>
-        </supports>
-        <supported-locale>fr</supported-locale>
-        <supported-locale>en</supported-locale>
-        <portlet-info>
-            <title>esup-filemanager</title>
-            <short-title>esup-filemanager</short-title>
-            <keywords>esup-filemanager</keywords>
-        </portlet-info>  
-        <portlet-preferences>
-        	<preference>
-        		<name>defaultPortletView</name>
-        		<value>standard</value>
-        	</preference>
-        	<preference>
-        		<name>defaultPath</name>
-        		<value>FS:</value>
-        		<!--value>FS:Shared~bob~home/bob</value-->
-        	</preference>    
-        	<preference>
-        		<name>showHiddenFiles</name>
-        		<value>false</value>
-        	</preference> 	
-        	<preference>
-        		<name>useDoubleClick</name>
-        		<value>true</value>
-        	</preference>  	
-        	<preference>
-        		<name>useCursorWaitDialog</name>
-        		<value>false</value>
-        	</preference> 	
-        	<preference>
-        		<name>fullDesktopViewOnlyOnMaximizedWindowState</name>
-        		<value>true</value>
-        	</preference> 	
-        	<preference>
-        		<name>forceMaximizedView4MobileWhenBrowsing</name>
-        		<value>true</value>
-        	</preference>     	
-        </portlet-preferences>
-    	
-	<supported-processing-event>
-		<qname xmlns:x="https://www.esup-portail.org/schemas/esup-filemanager">x:DownloadRequest</qname>
-	</supported-processing-event>
-	
-	<supported-processing-event>
-		<qname xmlns:x="https://source.jasig.org/schemas/uportal/search">x:SearchRequest</qname>
-	</supported-processing-event>
-	
-	<supported-publishing-event>
-		<qname xmlns:x="https://www.esup-portail.org/schemas/esup-filemanager">x:DownloadResponse</qname>
-	</supported-publishing-event>
-		
-	<supported-publishing-event>
-		<qname xmlns:x="https://source.jasig.org/schemas/uportal/search">x:SearchResults</qname>
-	</supported-publishing-event>
+  <portlet>
+    <portlet-name>esup-filemanager</portlet-name>
+    <display-name xml:lang="fr">esup-filemanager</display-name>
+    <portlet-class>org.esupportail.portlet.filemanager.portlet.CustomDispatcherPortlet</portlet-class>
+    <init-param>
+      <name>contextConfigLocation</name>
+      <value>WEB-INF/context/portlet/portletContext.xml</value>
+    </init-param>
+    <expiration-cache>0</expiration-cache>
+    <supports>
+      <mime-type>text/html</mime-type>
+      <portlet-mode>VIEW</portlet-mode>
+      <portlet-mode>EDIT</portlet-mode>
+      <portlet-mode>HELP</portlet-mode>
+      <portlet-mode>ABOUT</portlet-mode>
+    </supports>
+    <supported-locale>fr</supported-locale>
+    <supported-locale>en</supported-locale>
+    <portlet-info>
+      <title>esup-filemanager</title>
+      <short-title>esup-filemanager</short-title>
+      <keywords>esup-filemanager</keywords>
+    </portlet-info>
+    <portlet-preferences>
+      <preference>
+        <name>defaultPortletView</name>
+        <value>standard</value>
+      </preference>
+      <preference>
+        <name>defaultPath</name>
+        <value>FS:</value>
+        <!--value>FS:Shared~bob~home/bob</value-->
+      </preference>
+      <preference>
+        <name>showHiddenFiles</name>
+        <value>false</value>
+      </preference>
+      <preference>
+        <name>useDoubleClick</name>
+        <value>true</value>
+      </preference>
+      <preference>
+        <name>useCursorWaitDialog</name>
+        <value>false</value>
+      </preference>
+      <preference>
+        <name>fullDesktopViewOnlyOnMaximizedWindowState</name>
+        <value>true</value>
+      </preference>
+      <preference>
+        <name>forceMaximizedView4MobileWhenBrowsing</name>
+        <value>true</value>
+      </preference>
+    </portlet-preferences>
 
-        
-    </portlet>
+    <supported-processing-event>
+      <qname xmlns:x="https://www.esup-portail.org/schemas/esup-filemanager">x:DownloadRequest</qname>
+    </supported-processing-event>
 
-    
-    <user-attribute>
-        <description>CAS Proxy Ticket</description>
-        <name>casProxyTicket</name>
-    </user-attribute>
-    <user-attribute>
-        <description>luid</description>
-        <name>luid</name>
-    </user-attribute>
-    <user-attribute>
-        <description>uid</description>
-        <name>uid</name>
-    </user-attribute>
-    <user-attribute>
-        <description>affiliation</description>
-        <name>affiliation</name>
-    </user-attribute>
-    <user-attribute>
-        <description>composante</description>
-        <name>composante</name>
-    </user-attribute>
+    <supported-processing-event>
+      <qname xmlns:x="https://source.jasig.org/schemas/uportal/search">x:SearchRequest</qname>
+    </supported-processing-event>
 
-    <event-definition>
-        <qname xmlns:x="https://www.esup-portail.org/schemas/esup-filemanager">x:DownloadRequest</qname>
-        <value-type>org.esupportail.portlet.filemanager.api.DownloadRequest</value-type>
-    </event-definition>
-	<event-definition>
-        <qname xmlns:x="https://www.esup-portail.org/schemas/esup-filemanager">x:DownloadResponse</qname>
-        <value-type>org.esupportail.portlet.filemanager.api.DownloadResponse</value-type>
-    </event-definition>
-	
-    <event-definition>
-        <qname xmlns:x="https://source.jasig.org/schemas/uportal/search">x:SearchRequest</qname>
-        <value-type>org.jasig.portal.search.SearchRequest</value-type>
-    </event-definition>
-    <event-definition>
-        <qname xmlns:x="https://source.jasig.org/schemas/uportal/search">x:SearchResults</qname>
-        <value-type>org.jasig.portal.search.SearchResults</value-type>
-    </event-definition>
-    
+    <supported-publishing-event>
+      <qname xmlns:x="https://www.esup-portail.org/schemas/esup-filemanager">x:DownloadResponse</qname>
+    </supported-publishing-event>
+
+    <supported-publishing-event>
+      <qname xmlns:x="https://source.jasig.org/schemas/uportal/search">x:SearchResults</qname>
+    </supported-publishing-event>
+
+
+  </portlet>
+
+
+  <user-attribute>
+    <description>CAS Proxy Ticket</description>
+    <name>casProxyTicket</name>
+  </user-attribute>
+  <user-attribute>
+    <description>luid</description>
+    <name>luid</name>
+  </user-attribute>
+  <user-attribute>
+    <description>uid</description>
+    <name>uid</name>
+  </user-attribute>
+  <user-attribute>
+    <description>affiliation</description>
+    <name>affiliation</name>
+  </user-attribute>
+  <user-attribute>
+    <description>composante</description>
+    <name>composante</name>
+  </user-attribute>
+
+  <event-definition>
+    <qname xmlns:x="https://www.esup-portail.org/schemas/esup-filemanager">x:DownloadRequest</qname>
+    <value-type>org.esupportail.portlet.filemanager.api.DownloadRequest</value-type>
+  </event-definition>
+  <event-definition>
+    <qname xmlns:x="https://www.esup-portail.org/schemas/esup-filemanager">x:DownloadResponse</qname>
+    <value-type>org.esupportail.portlet.filemanager.api.DownloadResponse</value-type>
+  </event-definition>
+
+  <event-definition>
+    <qname xmlns:x="https://source.jasig.org/schemas/uportal/search">x:SearchRequest</qname>
+    <value-type>org.jasig.portal.search.SearchRequest</value-type>
+  </event-definition>
+  <event-definition>
+    <qname xmlns:x="https://source.jasig.org/schemas/uportal/search">x:SearchResults</qname>
+    <value-type>org.jasig.portal.search.SearchResults</value-type>
+  </event-definition>
+
 </portlet-app>


### PR DESCRIPTION
Referenced to spring-webmvc change that do a forward for resource request whereas include was used before.
After spring 3.1.2 we get this issue: https://github.com/spring-projects/spring-framework/issues/15417 which is caused by this commit: https://github.com/spring-projects/spring-framework/commit/b17d53ffae3b464ce1e550e3a4bc1c3073087323 -  `DispatcherPortlet uses a forward for rendering a view as resource response Issue: SPR-9876`